### PR TITLE
Redirect HTTP to HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightinteractive/bright-js-framework",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "description": "React at the speed of ⚡️",
   "devDependencies": {
     "@types/autoprefixer": "^6.7.3",


### PR DESCRIPTION
Although the app can be hit directly over HTTP (i.e. the connection from the load balancer to the instance is over http), the customer should always be forced to use HTTPS.