### PR TITLE
Fix HTTP Redirect for HealthCheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightinteractive/bright-js-framework",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "React at the speed of ⚡️",
   "devDependencies": {
     "@types/autoprefixer": "^6.7.3",

--- a/src/cli/local-commands/run.command.ts
+++ b/src/cli/local-commands/run.command.ts
@@ -29,7 +29,7 @@ export const builder = {
 }
 
 export const enforceCustomerFacingHttps: express.RequestHandler = (req, res, next) => {
-  if (req.headers['x-forwarded-proto'] !== 'https') {
+  if (req.headers['x-forwarded-proto'] === 'http') {
     return res.redirect(301, ['https://', req.get('Host'), req.url].join(''))
   }
   return next()


### PR DESCRIPTION
!== 'https' matches undefined, which is what happens when the health check calls the service. As teh health check isn't a forwared request, the protocol is undefined. We don't want to redirect in this case, we only want to serve a redirect to requests which were actually forwarded over HTTP...