### PR TITLE
Fixes to services and service test fixture

### DIFF
--- a/docs-site/src/pages/docs/fetching-data.js
+++ b/docs-site/src/pages/docs/fetching-data.js
@@ -51,8 +51,7 @@ export default () => {
           additional hooks. These differ from React lifecycle hooks, in that they can be asynchronous.
         </p>
         <p>
-          If a service implements <code>serviceWillLoad</code> and/or <code>serviceDidLoad</code>, these will be called in
-          order whenever:
+          If a service implements <code>serviceWillLoad</code>, this will be called whenever:
         </p>
         <ul>
           <li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightinteractive/bright-js-framework",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "React at the speed of ⚡️",
   "devDependencies": {
     "@types/apollo-codegen": "^0.16.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,7 +276,7 @@ export function state(key: string): PropertyDecorator {
  * ```
  */
 export function select<T, Props = {}>(selectFn: SelectFn<T, Props>, props?: (x: {}) => Props): PropertyDecorator {
-  return createSelectService(selectFn)
+  return decorateServiceProperty(createSelectService(selectFn, props))
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,8 +216,8 @@ export interface Action {
  *
  * Passed to the @select() decorator
  */
-export interface SelectFn<T> {
-  (state: any): T
+export interface SelectFn<T, Props = {}> {
+  (state: any, props?: Props): T
 }
 
 /**
@@ -275,7 +275,7 @@ export function state(key: string): PropertyDecorator {
  *  }
  * ```
  */
-export function select<T>(selectFn: SelectFn<T>): PropertyDecorator {
+export function select<T, Props = {}>(selectFn: SelectFn<T, Props>, props?: (x: {}) => Props): PropertyDecorator {
   return createSelectService(selectFn)
 }
 

--- a/src/lib/core/App.test.tsx
+++ b/src/lib/core/App.test.tsx
@@ -94,7 +94,7 @@ describe('App', () => {
 
   it('should not render transitioned routes until data is loaded', async () => {
     const {MountSpy, didMount} = mountSpy()
-    const {SpyService, serviceDidLoad} = spyService()
+    const {SpyService, serviceWillLoad} = spyService()
     const {Controller, componentDidMount} = spyController({services: [SpyService]})
 
     const mountedApp = mount<AppProps>(
@@ -117,7 +117,7 @@ describe('App', () => {
     mountedApp.props().history.replace('/2')
     await didMount
 
-    expect(serviceDidLoad).to.have.been.calledBefore(componentDidMount)
+    expect(serviceWillLoad).to.have.been.calledBefore(componentDidMount)
   })
 
   it('calls pageWillTransition on all plugins before next route is loaded', () => {

--- a/src/lib/core/ApplicationContext.test.ts
+++ b/src/lib/core/ApplicationContext.test.ts
@@ -23,4 +23,57 @@ describe('ApplicationContext', () => {
     const ctx = new ApplicationContext([MyPlugin])
     expect(ctx.store.dispatch).to.be.a('function')
   })
+
+  it('should allow state to be set and get on plugins', () => {
+    const ctx = new ApplicationContext([MyPlugin])
+    const plugin = ctx.findPluginOfType(MyPlugin)
+
+    plugin.setState({ foo: 1 })
+    expect(plugin.state).to.eql({ foo: 1 })
+  })
+
+  describe('loading a plugin', () => {
+    it('should call serviceWillLoad on plugins', async () => {
+      const ctx = new ApplicationContext([MyPlugin])
+      const plugin = ctx.findPluginOfType(MyPlugin)
+
+      let loaded = false
+      plugin.serviceWillLoad = function(this: MyPlugin) {
+        loaded = true
+      }
+
+      await ctx.applicationWillLoad()
+      expect(loaded).to.be.true
+    })
+  })
+
+  describe('before application mounts', () => {
+    it('should call serviceWillMount on services', () => {
+      const ctx = new ApplicationContext([MyPlugin])
+      const plugin = ctx.findPluginOfType(MyPlugin)
+
+      let willMountCalled = false
+      plugin.serviceWillMount = function(this: MyPlugin) {
+        willMountCalled = true
+      }
+
+      ctx.applicationWillMount()
+      expect(willMountCalled).to.be.true
+    })
+  })
+
+  describe('after application mounts', () => {
+    it('should call serviceDidMount on services', () => {
+      const ctx = new ApplicationContext([MyPlugin])
+      const plugin = ctx.findPluginOfType(MyPlugin)
+
+      let mounted = false
+      plugin.serviceDidMount = function(this: MyPlugin) {
+        mounted = true
+      }
+
+      ctx.applicationDidMount()
+      expect(mounted).to.be.true
+    })
+  })
 })

--- a/src/lib/core/load.test.tsx
+++ b/src/lib/core/load.test.tsx
@@ -6,7 +6,7 @@ import { spyController } from './mocks/SpyController'
 import { spyService } from './mocks/SpyService'
 import { Service, decorateServiceProperty } from './Service'
 import { decorateController } from './Controller'
-import { ControllerTestFixture } from '../fixtures/ControllerTestFixture';
+import { ControllerTestFixture } from '../fixtures/ControllerTestFixture'
 
 describe('load()', () => {
   it('should descend shallowly through primitive element types', async () => {
@@ -114,14 +114,12 @@ describe('load()', () => {
     const {
       SpyService: ChildService,
       serviceWillLoad: childWillLoad,
-      serviceDidLoad: childDidLoad,
       serviceWillMount: childWillMount
     } = spyService()
 
     const {
       SpyService: ParentService,
       serviceWillLoad: parentWillLoad,
-      serviceDidLoad: parentDidLoad,
       serviceWillMount: parentWillMount
     } = spyService([ChildService])
 
@@ -136,8 +134,6 @@ describe('load()', () => {
     expect(parentWillMount).to.have.been.calledBefore(parentWillLoad)
     expect(parentWillLoad).to.have.been.calledBefore(childWillMount)
     expect(childWillMount).to.have.been.calledBefore(childWillLoad)
-    expect(childWillLoad).to.have.been.calledBefore(childDidLoad)
-    expect(childDidLoad).to.have.been.calledBefore(parentDidLoad)
   })
 
   it('should not call serviceDidMount on services', async () => {

--- a/src/lib/core/load.ts
+++ b/src/lib/core/load.ts
@@ -103,10 +103,6 @@ export async function loadService(service: Service) {
   await Promise.all(
     gatherServices(service, { recursive: false }).map(loadService)
   )
-
-  if (service.serviceDidLoad) {
-    await service.serviceDidLoad()
-  }
 }
 
 export function mountComponent<P>(type: React.ComponentClass<P>, props: P, context: {}): React.Component<{}, {}> {

--- a/src/lib/core/mocks/SpyPlugin.ts
+++ b/src/lib/core/mocks/SpyPlugin.ts
@@ -17,13 +17,11 @@ export interface SpyPluginResult {
   serviceWillMount: SinonSpy,
   serviceDidMount: SinonSpy,
   serviceWillLoad: SinonSpy,
-  serviceDidLoad: SinonSpy,
   pageWillTransition: SinonSpy,
 }
 
 export function spyPlugin(): SpyPluginResult {
   const serviceWillLoad = spy()
-  const serviceDidLoad = spy()
   const serviceWillMount = spy()
   const serviceDidMount = spy()
   const pageWillTransition = spy()
@@ -33,7 +31,6 @@ export function spyPlugin(): SpyPluginResult {
       super(context)
 
       this.serviceWillLoad = serviceWillLoad
-      this.serviceDidLoad = serviceDidLoad
       this.serviceWillMount = serviceWillMount
       this.serviceDidMount = serviceDidMount
       this.pageWillTransition = pageWillTransition
@@ -43,7 +40,6 @@ export function spyPlugin(): SpyPluginResult {
   return {
     SpyPlugin: SpyPluginConfigClass,
     serviceWillLoad,
-    serviceDidLoad,
     serviceWillMount,
     serviceDidMount,
     pageWillTransition

--- a/src/lib/core/mocks/SpyService.ts
+++ b/src/lib/core/mocks/SpyService.ts
@@ -17,7 +17,6 @@ export interface SpyServiceResult {
   serviceWillMount: SinonSpy,
   serviceDidMount: SinonSpy,
   serviceWillLoad: SinonSpy,
-  serviceDidLoad: SinonSpy,
   serviceWillUnmount: SinonSpy,
 }
 
@@ -25,7 +24,6 @@ export function spyService(children: ServiceConstructor[] = []): SpyServiceResul
   const serviceWillMount = spy()
   const serviceDidMount = spy()
   const serviceWillLoad = spy()
-  const serviceDidLoad = spy()
   const serviceWillUnmount = spy()
 
   class SpyServiceClass extends Service {
@@ -35,7 +33,6 @@ export function spyService(children: ServiceConstructor[] = []): SpyServiceResul
       this.serviceWillMount = serviceWillMount
       this.serviceDidMount = serviceDidMount
       this.serviceWillLoad = serviceWillLoad
-      this.serviceDidLoad = serviceDidLoad
       this.serviceWillUnmount = serviceWillUnmount
     }
   }
@@ -47,7 +44,6 @@ export function spyService(children: ServiceConstructor[] = []): SpyServiceResul
     serviceWillMount,
     serviceDidMount,
     serviceWillLoad,
-    serviceDidLoad,
     serviceWillUnmount,
   }
 }

--- a/src/lib/entry/client.tsx
+++ b/src/lib/entry/client.tsx
@@ -50,12 +50,6 @@ export default async function clientEntry(modules: { pages: RequireList, plugins
     />
   ))
 
-  /** Fetch data required for the first render before loading */
-  async function prefetchData() {
-    await getAppContext().loadPlugins()
-    await load(renderApp())
-  }
-
   /** Get bundled routes and return configuration array for the router */
   function getRoutes(): RouteConfig[] {
     const routeComponents = getEntrypointExports(modules.pages, isRouteComponent)
@@ -67,7 +61,12 @@ export default async function clientEntry(modules: { pages: RequireList, plugins
   }
 
   restoreProcessEnv()
-  await prefetchData()
+
+  getAppContext().applicationWillMount()
+  await getAppContext().applicationWillLoad()
+  await load(renderApp())
 
   ReactDOM.render(renderApp(), document.getElementById('app'))
+
+  getAppContext().applicationDidMount()
 }

--- a/src/lib/entry/client.tsx
+++ b/src/lib/entry/client.tsx
@@ -10,7 +10,6 @@ import {createBrowserPlugin} from '../plugins/BrowserPlugin/BrowserPlugin'
 import {PluginConfig} from '../core/PluginConfig'
 import {getRouteComponentPath, isRouteComponent} from '../core/route'
 import {RouteConfig} from '../core/Router'
-import {asyncInvokeMethodOnAllObjects} from '../core/util'
 
 // Configuration passed from server in ‘magic’ variable
 declare const ___process_env_config: NodeJS.ProcessEnv
@@ -53,13 +52,8 @@ export default async function clientEntry(modules: { pages: RequireList, plugins
 
   /** Fetch data required for the first render before loading */
   async function prefetchData() {
-    const {plugins} = getAppContext()
-
-    await asyncInvokeMethodOnAllObjects(plugins, (plugin) => plugin.serviceWillLoad)
-
+    await getAppContext().loadPlugins()
     await load(renderApp())
-
-    await asyncInvokeMethodOnAllObjects(plugins, (plugin) => plugin.serviceDidLoad)
   }
 
   /** Get bundled routes and return configuration array for the router */

--- a/src/lib/entry/server.ts
+++ b/src/lib/entry/server.ts
@@ -1,4 +1,3 @@
-import 'ts-node/register'
 import 'colors'
 import * as express from 'express'
 import { Express } from 'express-serve-static-core'

--- a/src/lib/fixtures/ControllerTestFixture.tsx
+++ b/src/lib/fixtures/ControllerTestFixture.tsx
@@ -41,6 +41,8 @@ export class ControllerTestFixture<Controller extends React.Component = React.Co
           {this.markup}
         </ContextProvider>
       )
+
+      this.appContext.applicationDidMount()
     }
 
     return this.reactWrapper.update()
@@ -54,8 +56,11 @@ export class ControllerTestFixture<Controller extends React.Component = React.Co
     this.render().unmount()
   }
 
-  private load() {
-    return load(
+  private async load() {
+    this.appContext.applicationWillMount()
+    await this.appContext.applicationWillLoad()
+
+    await load(
       <ContextProvider appContext={this.appContext}>
         {this.markup}
       </ContextProvider>

--- a/src/lib/fixtures/ServiceTestFixture.test.ts
+++ b/src/lib/fixtures/ServiceTestFixture.test.ts
@@ -111,7 +111,6 @@ describe('ServiceTestFixture', () => {
       })
 
       expect(fixture.service.serviceWillLoad).to.have.been.calledOnce
-      expect(fixture.service.serviceDidLoad).to.have.been.calledAfter(fixture.service.serviceWillLoad as SinonSpy)
     })
 
     it('component should be unmounted', async () => {

--- a/src/lib/fixtures/ServiceTestFixture.ts
+++ b/src/lib/fixtures/ServiceTestFixture.ts
@@ -52,6 +52,13 @@ export class ServiceTestFixture<ServiceType extends Service> extends TestFixture
 
     this.allServices
       .forEach((service) => {
+        if (service.serviceWillMount) {
+          service.serviceWillMount()
+        }
+      })
+
+    this.allServices
+      .forEach((service) => {
         if (service.serviceDidMount) {
           service.serviceDidMount()
         }
@@ -68,10 +75,6 @@ export class ServiceTestFixture<ServiceType extends Service> extends TestFixture
       if (callback) {
         callback()
       }
-    }
-
-    if (service.serviceWillMount) {
-      service.serviceWillMount()
     }
   }
 }

--- a/src/lib/fixtures/ServiceTestFixture.ts
+++ b/src/lib/fixtures/ServiceTestFixture.ts
@@ -50,7 +50,12 @@ export class ServiceTestFixture<ServiceType extends Service> extends TestFixture
 
     this.service = new this.serviceConstructor({'@appContext': this.appContext}, {}) as ServiceType
 
-    this.allServices.forEach(this.initializeService)
+    this.allServices.forEach((service: Service) => {
+      const container = new ServiceContainer()
+      container.props = this.serviceProps
+
+      initializeService(service, container)
+    })
 
     this.allServices.forEach((service) => {
       if (service.serviceWillMount) {
@@ -65,12 +70,5 @@ export class ServiceTestFixture<ServiceType extends Service> extends TestFixture
     })
 
     this.appContext.applicationDidMount()
-  }
-
-  private initializeService = (service: Service) => {
-    const container = new ServiceContainer()
-    container.props = this.serviceProps
-
-    initializeService(service, container)
   }
 }

--- a/src/lib/fixtures/TestFixture.tsx
+++ b/src/lib/fixtures/TestFixture.tsx
@@ -7,7 +7,7 @@ import { PluginConstructor, PluginConfig } from '../core/PluginConfig'
 import { ApplicationContext } from '../core/ApplicationContext'
 import { createBrowserPlugin } from '../plugins/BrowserPlugin/BrowserPlugin'
 import { ServiceConstructor, Service, decorateServiceProperty } from '../core/Service'
-import { createSelectService, StateSelector } from '../plugins/StorePlugin/SelectService'
+import { createSelectService } from '../plugins/StorePlugin/SelectService'
 import { createSelectSpyService, SelectSpy } from '../plugins/StorePlugin/SelectorSpyService'
 
 export interface TestFixtureProps {
@@ -71,7 +71,7 @@ export abstract class TestFixture<Instance> {
   }
 
   async applySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T> {
-    const selector = await this.apply<StateSelector<T>>(createSelectService(selectFn, () => props))
+    const selector = await this.applyService(createSelectService(selectFn, () => props))
     return selector.value
   }
 

--- a/src/lib/plugins/BrowserPlugin/BrowserPlugin.test.tsx
+++ b/src/lib/plugins/BrowserPlugin/BrowserPlugin.test.tsx
@@ -11,7 +11,7 @@ import { BrowserActions } from './BrowserActions'
 describe('BrowserPlugin', () => {
   @decorateController
   class LocationView extends React.PureComponent {
-    @createSelectService(locationSelect)
+    @decorateServiceProperty(createSelectService(locationSelect))
     location: StateSelector<Location>
 
     @decorateServiceProperty(BrowserActions)

--- a/src/lib/plugins/GraphQLPlugin/GraphQLQueryService.ts
+++ b/src/lib/plugins/GraphQLPlugin/GraphQLQueryService.ts
@@ -26,13 +26,15 @@ export interface GraphQLQueryServiceState {
 }
 
 export function decorateGraphQLQuery(query: DocumentNode, opts: GraphQLQueryProps = {}) {
+  const errorSelector = (state: any, props: {}) => GraphQLPlugin.selectErrors({ variables: props, query })(state)
+
   class GraphQLQueryServiceImpl<Result> extends Service<GraphQLQueryServiceState> {
     private queryObserver: Subscription
 
     @injectDependency(ApolloClient)
     client: ApolloClient<any>
 
-    @createSelectService((state, props) => GraphQLPlugin.selectErrors({ variables: props, query })(state))
+    @decorateServiceProperty(createSelectService(errorSelector))
     errors: StateSelector<GraphQLError[]>
 
     @injectDispatch

--- a/src/lib/plugins/GraphQLServerPlugin/GraphQLServer.test.ts
+++ b/src/lib/plugins/GraphQLServerPlugin/GraphQLServer.test.ts
@@ -110,6 +110,20 @@ describe('GraphQLServer', () => {
     })
   })
 
+  it('should generate stub schema when missing a resolve', () => {
+    const server = new GraphQLServer({
+      connectors: [],
+      schema: [
+        {
+          resolvers: [],
+          typeDefs: UserSchema
+        }
+      ]
+    })
+
+    expect(server.schema!.getTypeMap()).to.contain.keys('User')
+  })
+
   it('should return an choose an aribitrary resolver on conflict between resolvers', async () => {
     @decorateSchemaType('Query')
     class QueryResolver1 extends SchemaType {

--- a/src/lib/plugins/GraphQLServerPlugin/GraphQLServer.test.ts
+++ b/src/lib/plugins/GraphQLServerPlugin/GraphQLServer.test.ts
@@ -110,7 +110,7 @@ describe('GraphQLServer', () => {
     })
   })
 
-  it('should generate stub schema when missing a resolve', () => {
+  it('should generate stub schema when missing a resolver', () => {
     const server = new GraphQLServer({
       connectors: [],
       schema: [

--- a/src/lib/plugins/GraphQLServerPlugin/GraphQLServer.ts
+++ b/src/lib/plugins/GraphQLServerPlugin/GraphQLServer.ts
@@ -78,9 +78,6 @@ export class GraphQLServer {
    */
   private createSchemaModule(config: { typeDefs: DocumentNode | string, resolvers: Array<typeof SchemaType> }): GraphQLSchema | undefined {
     const resolverTypes = config.resolvers
-    if (resolverTypes.length === 0) {
-      return undefined
-    }
 
     const resolvers = this.createFieldResolversForTypes(resolverTypes)
 
@@ -122,4 +119,3 @@ export class GraphQLServer {
     }
   }
 }
-

--- a/src/lib/plugins/GraphQLTestPlugin/GraphQLTestPlugin.ts
+++ b/src/lib/plugins/GraphQLTestPlugin/GraphQLTestPlugin.ts
@@ -6,12 +6,11 @@ import { ApolloClient } from 'apollo-client'
 import { addMockFunctionsToSchema, makeExecutableSchema } from 'graphql-tools'
 import { GraphQLFieldResolver, DocumentNode } from 'graphql'
 import { exportDependency, PluginConstructor } from '../../core/PluginConfig'
-import { getEntrypointExports, RequireList } from '../../bundler/Entrypoint'
+import { RequireList } from '../../bundler/Entrypoint'
 import { GraphQLServer } from '../GraphQLServerPlugin/GraphQLServer'
 import { LocalLink } from '../GraphQLPlugin/LocalLink'
 import GraphQLPluginBase from '../GraphQLPlugin/GraphQLPlugin.common'
 import { findGraphQLSources } from '../GraphQLServerPlugin/loadSchema'
-import { isSchemaType } from '../GraphQLServerPlugin/Resolver'
 
 export interface GraphQlPluginProps {
   schema?: DocumentNode | string
@@ -53,7 +52,7 @@ function getApplicationSchema() {
     connectors: [],
     schema: schemas.map(({ typeDefs, resolvers }) => ({
       typeDefs: require(typeDefs),
-      resolvers: getEntrypointExports(createRequireList(resolvers), isSchemaType)
+      resolvers: []
     })),
   })
 

--- a/src/lib/plugins/GraphQLTestPlugin/GraphQLTestPlugin.ts
+++ b/src/lib/plugins/GraphQLTestPlugin/GraphQLTestPlugin.ts
@@ -30,8 +30,7 @@ export function graphQlTestPlugin({ schema, mocks }: GraphQlPluginProps): Plugin
   if (mocks && executableSchema) {
     addMockFunctionsToSchema({
       mocks,
-      schema: executableSchema,
-      preserveResolvers: true
+      schema: executableSchema
     })
   }
 

--- a/src/lib/plugins/StorePlugin/SelectService.ts
+++ b/src/lib/plugins/StorePlugin/SelectService.ts
@@ -1,5 +1,5 @@
 import {Store} from 'redux'
-import {decorateServiceProperty, Service, ServiceConstructor} from '../../core/Service'
+import {Service, ServiceConstructor} from '../../core/Service'
 import {injectStore} from './StorePlugin'
 
 export interface StateSelector<T> extends Service {
@@ -8,7 +8,7 @@ export interface StateSelector<T> extends Service {
 
 export type SelectServiceConstructor<T> = ServiceConstructor<StateSelector<T>>
 
-export function createSelectService(selector: (x: any, props?: any) => any, getProps?: (x: any) => any): any {
+export function createSelectService(selector: (x: any, props?: any) => any, getProps?: (x: any) => any): SelectServiceConstructor<any> {
   class SelectService extends Service<{ value: any }> {
     state = {value: undefined}
 
@@ -46,5 +46,5 @@ export function createSelectService(selector: (x: any, props?: any) => any, getP
     }
   }
 
-  return decorateServiceProperty(SelectService)
+  return SelectService
 }

--- a/src/lib/plugins/StorePlugin/SelectService.ts
+++ b/src/lib/plugins/StorePlugin/SelectService.ts
@@ -8,18 +8,22 @@ export interface StateSelector<T> extends Service {
 
 export type SelectServiceConstructor<T> = ServiceConstructor<StateSelector<T>>
 
-export function createSelectService(selector: (x: any, props: any) => any): any {
+export function createSelectService(selector: (x: any, props?: any) => any, getProps?: (x: any) => any): any {
   class SelectService extends Service<{ value: any }> {
     state = {value: undefined}
 
     @injectStore
     private store: Store<any>
 
+    get selectorProps() {
+      return getProps ? getProps(this.parent) : this.controllerProps
+    }
+
     unsubscribe: () => void
 
     handleStoreChange = () => {
       this.setState({
-        value: selector(this.store.getState(), this.controllerProps)
+        value: selector(this.store.getState(), this.selectorProps)
       })
     }
 
@@ -35,7 +39,7 @@ export function createSelectService(selector: (x: any, props: any) => any): any 
 
     get value() {
       if (typeof this.state.value === 'undefined') {
-        return selector(this.store.getState(), this.controllerProps)
+        return selector(this.store.getState(), this.selectorProps)
       }
 
       return this.state.value

--- a/src/lib/plugins/StorePlugin/SelectorSpyService.ts
+++ b/src/lib/plugins/StorePlugin/SelectorSpyService.ts
@@ -1,0 +1,70 @@
+import {Store} from 'redux'
+import {decorateServiceProperty, Service, ServiceConstructor} from '../../core/Service'
+import {injectStore} from './StorePlugin'
+
+export interface SelectSpy<T> extends Service {
+  readonly values: T[]
+  nextValue(): Promise<T>
+}
+
+export type SelectSpyServiceConstructor<T> = ServiceConstructor<SelectSpy<T>>
+
+export function createSelectSpyService<Props>(selector: (x: any, props: Props) => any, getProps?: (x: any) => Props): any {
+  class SelectSpyService extends Service<{ value: any }> implements SelectSpy<any> {
+    readonly values: any[] = [
+      this.currentValue
+    ]
+
+    private spys: Array<(x: any) => void> = []
+
+    controllerProps: Props
+
+    state = {value: undefined}
+
+    @injectStore
+    private store: Store<any>
+
+    unsubscribe: () => void
+
+    nextValue() {
+      return new Promise((resolve) => {
+        this.spys.push(resolve)
+      })
+    }
+
+    private get props() {
+      return getProps ? getProps(this.parent) : this.controllerProps
+    }
+
+    private get currentValue() {
+      return selector(this.store.getState(), this.props)
+    }
+
+    private get lastValue() {
+      return this.values[this.values.length - 1]
+    }
+
+    handleStoreChange = () => {
+      if (this.currentValue !== this.lastValue) {
+        this.values.push(this.currentValue)
+
+        this.spys.forEach((spy) => {
+          spy(this.currentValue)
+        })
+        this.spys = []
+      }
+    }
+
+    serviceDidMount() {
+      this.unsubscribe = this.store.subscribe(this.handleStoreChange)
+    }
+
+    serviceWillUnmount() {
+      if (this.unsubscribe) {
+        this.unsubscribe()
+      }
+    }
+  }
+
+  return decorateServiceProperty(SelectSpyService)
+}

--- a/src/lib/plugins/StorePlugin/StorePlugin.test.tsx
+++ b/src/lib/plugins/StorePlugin/StorePlugin.test.tsx
@@ -7,7 +7,9 @@ import * as React from 'react'
 import { createSelectService, StateSelector } from './SelectService'
 import { Dispatch } from 'redux'
 import { injectDispatch, createStorePlugin } from './StorePlugin'
-import { ControllerTestFixture } from '../../fixtures/ControllerTestFixture';
+import { ControllerTestFixture } from '../../fixtures/ControllerTestFixture'
+import { ServiceTestFixture } from '../../fixtures/ServiceTestFixture'
+import { decorateServiceProperty } from '../../core/Service'
 
 describe('StorePlugin', () => {
   class CounterPlugin extends PluginConfig {
@@ -25,7 +27,7 @@ describe('StorePlugin', () => {
 
   @decorateController
   class CounterView extends React.PureComponent<{ overrideValue?: number }> {
-    @counter
+    @decorateServiceProperty(counter)
     counter: StateSelector<number>
 
     @injectDispatch
@@ -78,6 +80,16 @@ describe('StorePlugin', () => {
 
     expect(fixture.instance.counter.value).to.eql(123
     )
+  })
+
+  it('should use props function if provided', async () => {
+    const selector = (_: {}, props: { value: number}) => props.value
+    const fixture = await ServiceTestFixture.create({
+      plugins: [CounterPlugin],
+      service: createSelectService(selector, () => ({ value: 3 }))
+    })
+
+    expect(fixture.instance.value).to.eql(3)
   })
 
   it('should not create a store if no reducers are installed', () => {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -28,27 +28,27 @@ export interface TestFixture<Instance> {
   /**
    * Apply a property decorator to instance and return the result of the decorated property.
    */
-  apply<T>(decorator: PropertyDecorator): T
+  apply<T>(decorator: PropertyDecorator): Promise<T>
 
   /**
    * Create and attach a service to instance and return the instance of the service.
    */
-  applyService<S extends Service>(serviceType: new (context: ServiceContext, parent: {}) => S): S
+  applyService<S extends Service>(serviceType: new (context: ServiceContext, parent: {}) => S): Promise<S>
 
   /**
    * Create and attach a selector to instance and return the selected value.
    */
-  applySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): T
+  applySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T>
 
   /**
    * Create and attach a selector to instance and return an array that fills with each new selected value.
    */
-  spySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): T[]
+  spySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T[]>
 
   /**
    * Create and attach a selector to instance and return a promise that resolves on the next value change.
    */
-  nextSelectorValue<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T>
+  nextValueOf<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T>
 
   /**
    * Get a plugin of a specified type. If it exists, it will be returned.

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -31,6 +31,26 @@ export interface TestFixture<Instance> {
   apply<T>(decorator: PropertyDecorator): T
 
   /**
+   * Create and attach a service to instance and return the instance of the service.
+   */
+  applyService<S extends Service>(serviceType: new (context: ServiceContext, parent: {}) => S): S
+
+  /**
+   * Create and attach a selector to instance and return the selected value.
+   */
+  applySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): T
+
+  /**
+   * Create and attach a selector to instance and return an array that fills with each new selected value.
+   */
+  spySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): T[]
+
+  /**
+   * Create and attach a selector to instance and return a promise that resolves on the next value change.
+   */
+  nextSelectorValue<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T>
+
+  /**
    * Get a plugin of a specified type. If it exists, it will be returned.
    * If it does not exist, an exception is thrown.
    *


### PR DESCRIPTION
* Previously if a service was installed on a plugin, it couldn't be stateful or have load hooks. This now works as expected.
* Previously services in test fixtures didn't always get their lifecycle events called properly. This is also fixed.
* Added some useful helpers to ServiceTestFixture to simplify attaching and testing services and selectors.