### PR TITLE
Fix GraphQL sometimes ignoring resolvers given the @queries and @mutations annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightinteractive/bright-js-framework",
-  "version": "5.2.2",
+  "version": "5.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/plugins/GraphQLServerPlugin/GraphQLServer.test.ts
+++ b/src/lib/plugins/GraphQLServerPlugin/GraphQLServer.test.ts
@@ -126,6 +126,36 @@ describe('GraphQLServer', () => {
     expect(result.data!.getOrganisation.id).to.eql('2')
   })
 
+  it('should merge resolvers for types split between different SchemaType classes but defined in the same .graphql file', async () => {
+    const server = new GraphQLServer({
+      connectors: [],
+      schema: [
+        {
+          typeDefs: UserAndOrganisationSchema,
+          resolvers: [
+            UserQuery,
+            UserResolver,
+            OrganisationQuery,
+            OrganisationResolver,
+          ]
+        }
+      ]
+    })
+
+    const result = await execute({
+      schema: server.schema!,
+      document: gql`
+        query {
+          getUser(id: "1") { id }
+          getOrganisation(id: "2") { id }
+        }
+      `
+    })
+
+    expect(result.data!.getUser.id).to.eql('1')
+    expect(result.data!.getOrganisation.id).to.eql('2')
+  })
+
   it('should choose an aribitrary resolver on conflict between resolvers', async () => {
     @decorateSchemaType('Query')
     class QueryResolver1 extends SchemaType {


### PR DESCRIPTION
Previously, GraphQLServer assumed that there would only be a single SchemaType class for each type defined in a given .graphql file. This meant that 2 classes implementing resolvers for the same type were sometimes not merged correctly. 

This change allows, for example, two classes to be given the @queries annotation, while providing resolvers for a Query type in the same .graphql file
  