### PR TITLE
Breaking: Add imperative API to set query variables on a GraphQL query

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,8 +224,11 @@ export interface SelectFn<T, Props = {}> {
  * Service created by the @select decorator containing current value of
  * an application state subscription.
  */
-export interface StateSelection<T> {
+export interface StateSelection<T, Props = {}> {
   value: T
+
+  /** Set the parameters passed to the selector function to select state */
+  setSelectionParams(props: Props): void
 }
 
 /** Dispatcher function injected by the @dispatcher() decorator */
@@ -275,8 +278,8 @@ export function state(key: string): PropertyDecorator {
  *  }
  * ```
  */
-export function select<T, Props = {}>(selectFn: SelectFn<T, Props>, props?: (x: {}) => Props): PropertyDecorator {
-  return decorateServiceProperty(createSelectService(selectFn, props))
+export function select<T, Props = {}>(selectFn: SelectFn<T, Props>): PropertyDecorator {
+  return decorateServiceProperty(createSelectService(selectFn))
 }
 
 /**

--- a/src/lib/core/Controller.tsx
+++ b/src/lib/core/Controller.tsx
@@ -108,14 +108,14 @@ export function injectControllerBehavior(ComponentClass: React.ComponentClass) {
     })
   })
 
-  patchReturnMethod(ComponentClass.prototype, 'render', function(this: Controller, prev?: React.ReactElement<{}> | null) {
+  patchReturnMethod(ComponentClass.prototype, 'render', function(this: Controller, prev: () => React.ReactElement<{}> | null | undefined) {
     const { shouldRender } = this['@subtreeLoader']
-    return shouldRender && prev || null
+    return shouldRender && prev() || null
   })
 
-  patchReturnMethod(ComponentClass.prototype, 'getChildContext', function(this: Controller, prev?: any) {
+  patchReturnMethod(ComponentClass.prototype, 'getChildContext', function(this: Controller, prev: () => any) {
     const { childLoadContext } = this['@subtreeLoader']
-    return childLoadContext && { ...prev, ...childLoadContext } || prev || {}
+    return childLoadContext && { ...prev(), ...childLoadContext } || prev() || {}
   })
 }
 

--- a/src/lib/core/ControllerSubtreeLoadingService.ts
+++ b/src/lib/core/ControllerSubtreeLoadingService.ts
@@ -81,7 +81,7 @@ export function controllerSubtreeLoadingService(): PropertyDecorator {
 
       this.setState({ dynamicLoadState: 'loading' })
 
-      await load(React.createElement(controller, props))
+      await load(React.createElement(controller, props), this.context)
 
       // Mount all descendents, then reqlinquish responsibility for loading descendents.
       this.setState({ dynamicLoadState: 'mounting-subtree' }, () => {

--- a/src/lib/core/util.ts
+++ b/src/lib/core/util.ts
@@ -18,11 +18,11 @@ export function patchMethod(object: any, method: string, impl: (this: any) => vo
  * Override a getter method with a method that receives the overridden getter method's
  * return value as a parameter.
  */
-export function patchReturnMethod<T, Key extends keyof T, Value>(object: T, method: Key, impl: (parentValue?: Value) => Value): () => Value
-export function patchReturnMethod(object: any, method: string, impl: (this: any) => void) {
+export function patchReturnMethod<T, Key extends keyof T, Value>(object: T, method: Key, impl: (parentValue: () => Value | undefined) => Value): () => Value
+export function patchReturnMethod(object: any, method: string, impl: (parentValue: () => any) => any) {
   const existingImplementation = object[method] as any
   object[method] = function() {
-    const prev = existingImplementation && existingImplementation.apply(this)
+    const prev = () => existingImplementation && existingImplementation.apply(this)
     return impl.call(this, prev)
   }
 

--- a/src/lib/fixtures/TestFixture.tsx
+++ b/src/lib/fixtures/TestFixture.tsx
@@ -71,17 +71,17 @@ export abstract class TestFixture<Instance> {
   }
 
   async applySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T> {
-    const selector = await this.applyService(createSelectService(selectFn, () => props))
+    const selector = await this.applyService(createSelectService(selectFn))
     return selector.value
   }
 
   async spySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T[]> {
-    const spy = await this.apply<SelectSpy<T>>(createSelectSpyService(selectFn, () => props))
+    const spy = await this.apply<SelectSpy<T>>(createSelectSpyService(selectFn))
     return spy.values
   }
 
   async nextValueOf<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T> {
-    const spy = await this.apply<SelectSpy<T>>(createSelectSpyService(selectFn, () => props))
+    const spy = await this.apply<SelectSpy<T>>(createSelectSpyService(selectFn))
     return spy.nextValue()
   }
 

--- a/src/lib/plugins/StorePlugin/StorePlugin.test.tsx
+++ b/src/lib/plugins/StorePlugin/StorePlugin.test.tsx
@@ -72,27 +72,33 @@ describe('StorePlugin', () => {
     expect(unsubscribe).to.have.been.calledOnce
   })
 
-  it('should pass controller props through to selector', async () => {
-    const fixture = await ControllerTestFixture.create<CounterView>({
-      plugins: [CounterPlugin],
-      markup: <CounterView overrideValue={123} />
-    })
-
-    expect(fixture.instance.counter.value).to.eql(123
-    )
-  })
-
-  it('should use props function if provided', async () => {
-    const selector = (_: {}, props: { value: number}) => props.value
-    const fixture = await ServiceTestFixture.create({
-      plugins: [CounterPlugin],
-      service: createSelectService(selector, () => ({ value: 3 }))
-    })
-
-    expect(fixture.instance.value).to.eql(3)
-  })
-
   it('should not create a store if no reducers are installed', () => {
     expect((createStorePlugin([]) as any).store).to.be.undefined
+  })
+
+  context('when props change', () => {
+    it('should update immediately', async () => {
+      const selector = (_: {}, props: { value: number}) => props.value
+      const fixture = await ServiceTestFixture.create({
+        plugins: [CounterPlugin],
+        service: createSelectService(selector)
+      })
+
+      fixture.instance.setSelectionParams({ value: 3 })
+      expect(fixture.instance.value).to.eql(3)
+    })
+    
+    it('should use params to select in future', async () => {
+      const selector = (_: {}, props: { value: number}) => props.value
+      const fixture = await ServiceTestFixture.create({
+        plugins: [CounterPlugin],
+        service: createSelectService(selector)
+      })
+
+      fixture.instance.setSelectionParams({ value: 3 })
+      fixture.store.dispatch({ type: 'increment' })
+
+      expect(fixture.instance.value).to.eql(3)
+    })
   })
 })

--- a/src/plugins/graphql/index.ts
+++ b/src/plugins/graphql/index.ts
@@ -15,7 +15,7 @@ export default function createGraphQLPlugin(props: GraphQlPluginOpts): PluginCon
   return _createGraphQLPlugin(props)
 }
 
-export interface GraphQLQuery<T> {
+export interface GraphQLQuery<T, Variables = {}> {
   /**
    * Current selected data for the query.
    *
@@ -23,6 +23,16 @@ export interface GraphQLQuery<T> {
    * not yet be available. This will throw an exception.
    */
   readonly data: T
+
+  /**
+   * Indicate whether or not data is currently being fetched
+   */
+  readonly loading: boolean
+
+  /**
+   * Set the query variables provided to the query
+   */
+  setQueryVariables(variables: Variables): void
 }
 
 export interface GraphQLQueryOpts {


### PR DESCRIPTION
This replaces the previous API, which implicitly inherited query variables from the react
component

This is:
   * Better for typesafety
   * More obvious (it wans't always clear where query variables were coming from before)
   * Works in environments where there aren't any component props (eg. plugins)
   * Removes need to 'nest' components unnecessarily (eg. if a query depends on state, rather than props of a parent component)

Component which provide variables to a query will need to be updated. They should use the new API to set query variables in `componentWillMount`
  