### PR TITLE
Fix issues loading data for dynamically inserted components

### DIFF
--- a/src/lib/core/Controller.tsx
+++ b/src/lib/core/Controller.tsx
@@ -108,14 +108,14 @@ export function injectControllerBehavior(ComponentClass: React.ComponentClass) {
     })
   })
 
-  patchReturnMethod(ComponentClass.prototype, 'render', function(this: Controller, prev?: React.ReactElement<{}> | null) {
+  patchReturnMethod(ComponentClass.prototype, 'render', function(this: Controller, prev: () => React.ReactElement<{}> | null | undefined) {
     const { shouldRender } = this['@subtreeLoader']
-    return shouldRender && prev || null
+    return shouldRender && prev() || null
   })
 
-  patchReturnMethod(ComponentClass.prototype, 'getChildContext', function(this: Controller, prev?: any) {
+  patchReturnMethod(ComponentClass.prototype, 'getChildContext', function(this: Controller, prev: () => any) {
     const { childLoadContext } = this['@subtreeLoader']
-    return childLoadContext && { ...prev, ...childLoadContext } || prev || {}
+    return childLoadContext && { ...prev(), ...childLoadContext } || prev() || {}
   })
 }
 

--- a/src/lib/core/ControllerSubtreeLoadingService.ts
+++ b/src/lib/core/ControllerSubtreeLoadingService.ts
@@ -81,7 +81,7 @@ export function controllerSubtreeLoadingService(): PropertyDecorator {
 
       this.setState({ dynamicLoadState: 'loading' })
 
-      await load(React.createElement(controller, props))
+      await load(React.createElement(controller, props), this.context)
 
       // Mount all descendents, then reqlinquish responsibility for loading descendents.
       this.setState({ dynamicLoadState: 'mounting-subtree' }, () => {

--- a/src/lib/core/util.ts
+++ b/src/lib/core/util.ts
@@ -18,11 +18,11 @@ export function patchMethod(object: any, method: string, impl: (this: any) => vo
  * Override a getter method with a method that receives the overridden getter method's
  * return value as a parameter.
  */
-export function patchReturnMethod<T, Key extends keyof T, Value>(object: T, method: Key, impl: (parentValue?: Value) => Value): () => Value
-export function patchReturnMethod(object: any, method: string, impl: (this: any) => void) {
+export function patchReturnMethod<T, Key extends keyof T, Value>(object: T, method: Key, impl: (parentValue: () => Value | undefined) => Value): () => Value
+export function patchReturnMethod(object: any, method: string, impl: (parentValue: () => any) => any) {
   const existingImplementation = object[method] as any
   object[method] = function() {
-    const prev = existingImplementation && existingImplementation.apply(this)
+    const prev = () => existingImplementation && existingImplementation.apply(this)
     return impl.call(this, prev)
   }
 


### PR DESCRIPTION
When a component with data dependencies is inserted into the DOM, it is expected that data dependencies for it will be resolved before the component is mounted and rendered.

An issue with the code responsible for this caused the render method to be called on these components before data dependencies had been resolved.

This PR fixes both of this issue and updates the test cases to use a more representative example of a data loader (previously, the above issue had not caused them to fail)