### PR TITLE
Revert "Breaking: Add imperative API to set query variables on a GraphQL query"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,11 +224,8 @@ export interface SelectFn<T, Props = {}> {
  * Service created by the @select decorator containing current value of
  * an application state subscription.
  */
-export interface StateSelection<T, Props = {}> {
+export interface StateSelection<T> {
   value: T
-
-  /** Set the parameters passed to the selector function to select state */
-  setSelectionParams(props: Props): void
 }
 
 /** Dispatcher function injected by the @dispatcher() decorator */
@@ -278,8 +275,8 @@ export function state(key: string): PropertyDecorator {
  *  }
  * ```
  */
-export function select<T, Props = {}>(selectFn: SelectFn<T, Props>): PropertyDecorator {
-  return decorateServiceProperty(createSelectService(selectFn))
+export function select<T, Props = {}>(selectFn: SelectFn<T, Props>, props?: (x: {}) => Props): PropertyDecorator {
+  return decorateServiceProperty(createSelectService(selectFn, props))
 }
 
 /**

--- a/src/lib/core/Controller.tsx
+++ b/src/lib/core/Controller.tsx
@@ -108,14 +108,14 @@ export function injectControllerBehavior(ComponentClass: React.ComponentClass) {
     })
   })
 
-  patchReturnMethod(ComponentClass.prototype, 'render', function(this: Controller, prev: () => React.ReactElement<{}> | null | undefined) {
+  patchReturnMethod(ComponentClass.prototype, 'render', function(this: Controller, prev?: React.ReactElement<{}> | null) {
     const { shouldRender } = this['@subtreeLoader']
-    return shouldRender && prev() || null
+    return shouldRender && prev || null
   })
 
-  patchReturnMethod(ComponentClass.prototype, 'getChildContext', function(this: Controller, prev: () => any) {
+  patchReturnMethod(ComponentClass.prototype, 'getChildContext', function(this: Controller, prev?: any) {
     const { childLoadContext } = this['@subtreeLoader']
-    return childLoadContext && { ...prev(), ...childLoadContext } || prev() || {}
+    return childLoadContext && { ...prev, ...childLoadContext } || prev || {}
   })
 }
 

--- a/src/lib/core/ControllerSubtreeLoadingService.ts
+++ b/src/lib/core/ControllerSubtreeLoadingService.ts
@@ -81,7 +81,7 @@ export function controllerSubtreeLoadingService(): PropertyDecorator {
 
       this.setState({ dynamicLoadState: 'loading' })
 
-      await load(React.createElement(controller, props), this.context)
+      await load(React.createElement(controller, props))
 
       // Mount all descendents, then reqlinquish responsibility for loading descendents.
       this.setState({ dynamicLoadState: 'mounting-subtree' }, () => {

--- a/src/lib/core/util.ts
+++ b/src/lib/core/util.ts
@@ -18,11 +18,11 @@ export function patchMethod(object: any, method: string, impl: (this: any) => vo
  * Override a getter method with a method that receives the overridden getter method's
  * return value as a parameter.
  */
-export function patchReturnMethod<T, Key extends keyof T, Value>(object: T, method: Key, impl: (parentValue: () => Value | undefined) => Value): () => Value
-export function patchReturnMethod(object: any, method: string, impl: (parentValue: () => any) => any) {
+export function patchReturnMethod<T, Key extends keyof T, Value>(object: T, method: Key, impl: (parentValue?: Value) => Value): () => Value
+export function patchReturnMethod(object: any, method: string, impl: (this: any) => void) {
   const existingImplementation = object[method] as any
   object[method] = function() {
-    const prev = () => existingImplementation && existingImplementation.apply(this)
+    const prev = existingImplementation && existingImplementation.apply(this)
     return impl.call(this, prev)
   }
 

--- a/src/lib/fixtures/TestFixture.tsx
+++ b/src/lib/fixtures/TestFixture.tsx
@@ -71,17 +71,17 @@ export abstract class TestFixture<Instance> {
   }
 
   async applySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T> {
-    const selector = await this.applyService(createSelectService(selectFn))
+    const selector = await this.applyService(createSelectService(selectFn, () => props))
     return selector.value
   }
 
   async spySelector<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T[]> {
-    const spy = await this.apply<SelectSpy<T>>(createSelectSpyService(selectFn))
+    const spy = await this.apply<SelectSpy<T>>(createSelectSpyService(selectFn, () => props))
     return spy.values
   }
 
   async nextValueOf<T, Props>(selectFn: (x: any, props?: Props) => T, props?: Props): Promise<T> {
-    const spy = await this.apply<SelectSpy<T>>(createSelectSpyService(selectFn))
+    const spy = await this.apply<SelectSpy<T>>(createSelectSpyService(selectFn, () => props))
     return spy.nextValue()
   }
 

--- a/src/lib/plugins/GraphQLPlugin/GraphQLQueryService.test.tsx
+++ b/src/lib/plugins/GraphQLPlugin/GraphQLQueryService.test.tsx
@@ -3,7 +3,7 @@ import gql from 'graphql-tag'
 import { expect } from 'chai'
 import { DocumentNode } from 'graphql'
 import { decorateController } from '../../core/Controller'
-import { GraphQLQueryService, decorateGraphQLQuery } from './GraphQLQueryService'
+import { GraphQLQueryService, decorateGraphQLQuery, GraphQLQueryProps } from './GraphQLQueryService'
 import { graphQlTestPlugin, GraphQlMocks } from '../GraphQLTestPlugin/GraphQLTestPlugin'
 import { ControllerTestFixture } from '../../fixtures/ControllerTestFixture'
 
@@ -15,25 +15,19 @@ const schema = `
 `
 
 describe('GraphQLQueryService', () => {
-  async function setup(opts: { query: DocumentNode, mocks: GraphQlMocks, props?: {} }) {
+  async function setup(opts: { query: DocumentNode, mocks: GraphQlMocks, props?: {}, decoratorOpts?: GraphQLQueryProps }) {
     @decorateController
     class Example extends React.PureComponent {
-      @decorateGraphQLQuery(opts.query)
+      @decorateGraphQLQuery(opts.query, opts.decoratorOpts)
       query: GraphQLQueryService<{ someString: string }>
-
-      componentWillMount() {
-        if (opts.props) {
-          this.query.setQueryVariables(opts.props)
-        }
-      }
 
       render() {
         return <div>{JSON.stringify(this.query.data)}</div>
       }
     }
 
-    const fixture = await ControllerTestFixture.create<Example>({
-      markup: <Example />,
+    const fixture = await ControllerTestFixture.create({
+      markup: <Example {...opts.props} />,
       plugins: [
         graphQlTestPlugin({
           schema,
@@ -86,10 +80,13 @@ describe('GraphQLQueryService', () => {
     expect(fixture.render()).to.have.text(JSON.stringify({ uppercaseString: 'FOO' }))
   })
 
-  it('should refetch when providing new props', async () => {
+  it('should allow specifying props in decorator opts', async () => {
     const fixture = await setup({
       props: {
-        sourceString: 'foo'
+        sourceStringProp: 'foo'
+      },
+      decoratorOpts: {
+        props: (parent) => ({ sourceString: parent.props.sourceStringProp })
       },
       query: gql`
         query($sourceString: String) {
@@ -107,14 +104,7 @@ describe('GraphQLQueryService', () => {
       }
     })
 
-    fixture.render()
-    fixture.instance.query.setQueryVariables({ sourceString: 'bar' })
-
-    do {
-      // yield to event loop
-      await Promise.resolve()
-    }
-    while (!fixture.render().text().match(JSON.stringify({ uppercaseString: 'BAR' })))
+    expect(fixture.render()).to.have.text(JSON.stringify({ uppercaseString: 'FOO' }))
   })
 
   it('should rethrow query errors in render', async () => {

--- a/src/lib/plugins/StorePlugin/SelectService.ts
+++ b/src/lib/plugins/StorePlugin/SelectService.ts
@@ -2,37 +2,28 @@ import {Store} from 'redux'
 import {Service, ServiceConstructor} from '../../core/Service'
 import {injectStore} from './StorePlugin'
 
-export interface StateSelector<T, Props = {}> extends Service {
+export interface StateSelector<T> extends Service {
   readonly value: T
-  setSelectionParams(props: Props): void
 }
 
 export type SelectServiceConstructor<T> = ServiceConstructor<StateSelector<T>>
 
-export function createSelectService(selector: (x: any, props?: any) => any): SelectServiceConstructor<any> {
+export function createSelectService(selector: (x: any, props?: any) => any, getProps?: (x: any) => any): SelectServiceConstructor<any> {
   class SelectService extends Service<{ value: any }> {
-    private props: {} = {}
+    state = {value: undefined}
 
     @injectStore
     private store: Store<any>
-    
-    private unsubscribe: () => void
 
-    get value() {
-      return this.state.value
+    get selectorProps() {
+      return getProps ? getProps(this.parent) : this.controllerProps
     }
 
-    setSelectionParams(props: any) {
-      this.props = props
+    unsubscribe: () => void
 
+    handleStoreChange = () => {
       this.setState({
-        value: this.select()
-      })
-    }
-
-    serviceWillMount() {
-      this.setState({
-        value: this.select()
+        value: selector(this.store.getState(), this.selectorProps)
       })
     }
 
@@ -46,14 +37,12 @@ export function createSelectService(selector: (x: any, props?: any) => any): Sel
       }
     }
 
-    private select() {
-      return selector(this.store.getState(), this.props)
-    }
-    
-    private handleStoreChange = () => {
-      this.setState({
-        value: this.select()
-      })
+    get value() {
+      if (typeof this.state.value === 'undefined') {
+        return selector(this.store.getState(), this.selectorProps)
+      }
+
+      return this.state.value
     }
   }
 

--- a/src/lib/plugins/StorePlugin/StorePlugin.test.tsx
+++ b/src/lib/plugins/StorePlugin/StorePlugin.test.tsx
@@ -72,33 +72,27 @@ describe('StorePlugin', () => {
     expect(unsubscribe).to.have.been.calledOnce
   })
 
-  it('should not create a store if no reducers are installed', () => {
-    expect((createStorePlugin([]) as any).store).to.be.undefined
+  it('should pass controller props through to selector', async () => {
+    const fixture = await ControllerTestFixture.create<CounterView>({
+      plugins: [CounterPlugin],
+      markup: <CounterView overrideValue={123} />
+    })
+
+    expect(fixture.instance.counter.value).to.eql(123
+    )
   })
 
-  context('when props change', () => {
-    it('should update immediately', async () => {
-      const selector = (_: {}, props: { value: number}) => props.value
-      const fixture = await ServiceTestFixture.create({
-        plugins: [CounterPlugin],
-        service: createSelectService(selector)
-      })
-
-      fixture.instance.setSelectionParams({ value: 3 })
-      expect(fixture.instance.value).to.eql(3)
+  it('should use props function if provided', async () => {
+    const selector = (_: {}, props: { value: number}) => props.value
+    const fixture = await ServiceTestFixture.create({
+      plugins: [CounterPlugin],
+      service: createSelectService(selector, () => ({ value: 3 }))
     })
-    
-    it('should use params to select in future', async () => {
-      const selector = (_: {}, props: { value: number}) => props.value
-      const fixture = await ServiceTestFixture.create({
-        plugins: [CounterPlugin],
-        service: createSelectService(selector)
-      })
 
-      fixture.instance.setSelectionParams({ value: 3 })
-      fixture.store.dispatch({ type: 'increment' })
+    expect(fixture.instance.value).to.eql(3)
+  })
 
-      expect(fixture.instance.value).to.eql(3)
-    })
+  it('should not create a store if no reducers are installed', () => {
+    expect((createStorePlugin([]) as any).store).to.be.undefined
   })
 })

--- a/src/plugins/graphql/index.ts
+++ b/src/plugins/graphql/index.ts
@@ -14,7 +14,7 @@ export default function createGraphQLPlugin(props: GraphQlPluginOpts): PluginCon
   return _createGraphQLPlugin(props)
 }
 
-export interface GraphQLQuery<T, Variables = {}> {
+export interface GraphQLQuery<T> {
   /**
    * Current selected data for the query.
    *
@@ -22,16 +22,6 @@ export interface GraphQLQuery<T, Variables = {}> {
    * not yet be available. This will throw an exception.
    */
   readonly data: T
-
-  /**
-   * Indicate whether or not data is currently being fetched
-   */
-  readonly loading: boolean
-
-  /**
-   * Set the query variables provided to the query
-   */
-  setQueryVariables(variables: Variables): void
 }
 
 export interface GraphQLQueryOpts {


### PR DESCRIPTION
Reverting this for now in order to think the API through better as it leads to issues with ordering of data dependencies.